### PR TITLE
Fixed faulty check

### DIFF
--- a/src/main/java/dev/dokan/dokan_java/examples/DirListingFileSystem.java
+++ b/src/main/java/dev/dokan/dokan_java/examples/DirListingFileSystem.java
@@ -93,7 +93,7 @@ public class DirListingFileSystem extends DokanyFileSystemStub {
         }
 
         if (Files.isDirectory(p)) {
-            if ((rawCreateOptions & CreateOptions.FILE_NON_DIRECTORY_FILE) == 1) {
+            if ((rawCreateOptions & CreateOptions.FILE_NON_DIRECTORY_FILE) != 0) {
                 return Win32ErrorCodes.ERROR_DIRECTORY;
             } else {
                 dokanFileInfo.IsDirectory = 1;


### PR DESCRIPTION
'rawCreateOptions & CreateOptions.FILE_NON_DIRECTORY_FILE' can only evaluate to FILE_NON_DIRECTORY_FILE or 0, but never 1.