### PR TITLE
Fix issue #46

### DIFF
--- a/MAPPING.md
+++ b/MAPPING.md
@@ -9,4 +9,4 @@
 # References
 Basic Types/Size: [Web](https://docs.microsoft.com/en-us/cpp/c-language/storage-of-basic-types?view=vs-2019) | [Permalink](https://web.archive.org/web/20200616151823/https://docs.microsoft.com/en-us/cpp/c-language/storage-of-basic-types?view=vs-2019) <br>
 Windows Data Types/Mapped C Data Types: [Web](https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types) | [Permalink](https://web.archive.org/web/20200616152122/https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types) <br>
-JNA Data Types: [Web](https://java-native-access.github.io/jna/4.2.1/com/sun/jna/platform/win32/WinDef.html) | [Permalink](https://web.archive.org/web/20200616153134/http://java-native-access.github.io/jna/4.2.1/com/sun/jna/platform/win32/WinDef.html) <br>
+JNA Data Types: [Web](https://java-native-access.github.io/jna/5.5.0/javadoc/com/sun/jna/platform/win32/WinDef.html) | [Permalink](https://web.archive.org/web/20200616212719/https://java-native-access.github.io/jna/5.5.0/javadoc/com/sun/jna/platform/win32/WinDef.html) <br>

--- a/MAPPING.md
+++ b/MAPPING.md
@@ -1,8 +1,12 @@
-| C++ Datatype        | C++/Dokany Makro | Size (Byte/bit) | java/JNA Datatyp                            |
-|---------------------|------------------|-----------------|---------------------------------------------|
-| char/byte           | UCHAR            | 1B/8b           | byte                                        |
-| unsigned short      | USHORT           | 2B/16b          | com.sun.jna.platform.win32.WinDef.USHORT    |
-| unsigned long (int) | ULONG            | 4B/32b          | com.sun.jna.platform.win32.WinDef.ULONG     |
-| unsigned long (int) | DWORD/AccessMask | 4B/32b          | com.sun.jna.platform.win32.WinDef.DWORD     |
-| unsigned __int64    | ULONG64          | 8B/64b          | com.sun.jna.platform.win32.WinDef.ULONGLONG |
-|                     |                  |                 |                                             |
+# Overview
+| C Data Type         | Windows Data Type - Macro | Size (Bytes/bits) | java/JNA Data Type                |
+|---------------------|---------------------------|-------------------|-----------------------------------|
+| char/byte           | UCHAR                     | 1B/8b             | byte                              |
+| unsigned short      | USHORT                    | 2B/16b            | short (@Unsigned)/WinDef.USHORT   |
+| unsigned long (int) | ULONG                     | 4B/32b            | int (@Unsigned)/WinDef.ULONG      |
+| unsigned long (int) | DWORD/AccessMask          | 4B/32b            | int (@Unsigned)/WinDef.DWORD      |
+| unsigned __int64    | ULONG64                   | 8B/64b            | long (@Unsigned)/WinDef.ULONGLONG |
+# References
+Basic Types/Size: [Web](https://docs.microsoft.com/en-us/cpp/c-language/storage-of-basic-types?view=vs-2019) | [Permalink](https://web.archive.org/web/20200616151823/https://docs.microsoft.com/en-us/cpp/c-language/storage-of-basic-types?view=vs-2019) <br>
+Windows Data Types/Mapped C Data Types: [Web](https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types) | [Permalink](https://web.archive.org/web/20200616152122/https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types) <br>
+JNA Data Types: [Web](https://java-native-access.github.io/jna/4.2.1/com/sun/jna/platform/win32/WinDef.html) | [Permalink](https://web.archive.org/web/20200616153134/http://java-native-access.github.io/jna/4.2.1/com/sun/jna/platform/win32/WinDef.html) <br>

--- a/MAPPING.md
+++ b/MAPPING.md
@@ -1,0 +1,8 @@
+| C++ Datatype        | C++/Dokany Makro | Size (Byte/bit) | java/JNA Datatyp                            |
+|---------------------|------------------|-----------------|---------------------------------------------|
+| char/byte           | UCHAR            | 1B/8b           | byte                                        |
+| unsigned short      | USHORT           | 2B/16b          | com.sun.jna.platform.win32.WinDef.USHORT    |
+| unsigned long (int) | ULONG            | 4B/32b          | com.sun.jna.platform.win32.WinDef.ULONG     |
+| unsigned long (int) | DWORD/AccessMask | 4B/32b          | com.sun.jna.platform.win32.WinDef.DWORD     |
+| unsigned __int64    | ULONG64          | 8B/64b          | com.sun.jna.platform.win32.WinDef.ULONGLONG |
+|                     |                  |                 |                                             |

--- a/src/main/java/dev/dokan/dokan_java/AbstractDokanFileSystem.java
+++ b/src/main/java/dev/dokan/dokan_java/AbstractDokanFileSystem.java
@@ -176,7 +176,7 @@ public abstract class AbstractDokanFileSystem implements DokanFileSystem {
 	 * @param options an {@link MaskValueSet} containing {@link MountOption}s
 	 */
 	@Override
-	public final synchronized void mount(Path mountPoint, String volumeName, int volumeSerialnumber, boolean blocking, long timeout, long allocationUnitSize, long sectorSize, String UNCName, short threadCount, MaskValueSet<MountOption> options) {
+	public final synchronized void mount(Path mountPoint, String volumeName, int volumeSerialnumber, boolean blocking, @Unsigned int timeout, @Unsigned int allocationUnitSize, @Unsigned int sectorSize, String UNCName, @Unsigned short threadCount, MaskValueSet<MountOption> options) {
 		this.dokanOptions = new DokanOptions(mountPoint.toString(), threadCount, options, UNCName, timeout, allocationUnitSize, sectorSize);
 		this.mountPoint = mountPoint;
 		this.volumeName = volumeName;
@@ -218,10 +218,10 @@ public abstract class AbstractDokanFileSystem implements DokanFileSystem {
 	 */
 	public void mount(Path mountPoint, MaskValueSet<MountOption> mountOptions) {
 		String uncName = null;
-		short threadCount = 5;
-		long timeout = 3000;
-		long allocationUnitSize = 4096;
-		long sectorsize = 512;
+		@Unsigned short threadCount = 5;
+		@Unsigned int timeout = 3000;
+		@Unsigned int allocationUnitSize = 4096;
+		@Unsigned int sectorsize = 512;
 		String volumeName = "DOKAN";
 		int volumeSerialnumber = 30975;
 		mount(mountPoint, volumeName, volumeSerialnumber, false, timeout, allocationUnitSize, sectorsize, uncName, threadCount, mountOptions);

--- a/src/main/java/dev/dokan/dokan_java/AbstractDokanFileSystem.java
+++ b/src/main/java/dev/dokan/dokan_java/AbstractDokanFileSystem.java
@@ -5,12 +5,12 @@ import com.sun.jna.CallbackThreadInitializer;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.WString;
-import com.sun.jna.ptr.LongByReference;
+import com.sun.jna.ptr.IntByReference;
 import dev.dokan.dokan_java.constants.dokany.MountError;
 import dev.dokan.dokan_java.constants.dokany.MountOption;
+import dev.dokan.dokan_java.masking.MaskValueSet;
 import dev.dokan.dokan_java.structure.DokanControl;
 import dev.dokan.dokan_java.structure.DokanOptions;
-import dev.dokan.dokan_java.masking.MaskValueSet;
 
 import java.lang.reflect.Method;
 import java.nio.file.Path;
@@ -248,9 +248,11 @@ public abstract class AbstractDokanFileSystem implements DokanFileSystem {
 
 	private boolean volumeIsStillMounted() {
 		char[] mntPtCharArray = mountPoint.toAbsolutePath().toString().toCharArray();
-		LongByReference length = new LongByReference();
-		Pointer startOfList = DokanNativeMethods.DokanGetMountPointList(false, length);
-		List<DokanControl> list = DokanControl.getDokanControlList(startOfList, length.getValue());
+		IntByReference lengthPointer = new IntByReference();
+		Pointer startOfList = DokanNativeMethods.DokanGetMountPointList(false, lengthPointer);
+
+		@Unsigned int length = lengthPointer.getValue();
+		List<DokanControl> list = DokanControl.getDokanControlList(startOfList, length);
 		// It is not enough that the entry.MountPoint contains the actual mount point. It also has to ends afterwards.
 		boolean mountPointInList = list.stream().anyMatch(entry ->
 				Arrays.equals(entry.MountPoint, 12, 12 + mntPtCharArray.length, mntPtCharArray, 0, mntPtCharArray.length)

--- a/src/main/java/dev/dokan/dokan_java/DokanNativeMethods.java
+++ b/src/main/java/dev/dokan/dokan_java/DokanNativeMethods.java
@@ -6,7 +6,6 @@ import com.sun.jna.Pointer;
 import com.sun.jna.WString;
 import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.ptr.IntByReference;
-import com.sun.jna.ptr.LongByReference;
 import com.sun.jna.win32.StdCallLibrary;
 import dev.dokan.dokan_java.constants.dokany.MountError;
 import dev.dokan.dokan_java.structure.DokanControl;
@@ -200,10 +199,10 @@ public class DokanNativeMethods implements StdCallLibrary {
 	 * </p>
 	 *
 	 * @param uncOnly - Get only instances that have UNC Name.
-	 * @param nbRead - Number of instances successfully retrieved
+	 * @param nbRead - {@link Unsigned} Number of instances successfully retrieved
 	 * @return a pointer to the start of the allocated array of {@link DokanControl} elemets.
 	 */
-	static native Pointer DokanGetMountPointList(boolean uncOnly, LongByReference nbRead);
+	static native Pointer DokanGetMountPointList(boolean uncOnly, @Unsigned IntByReference nbRead);
 
 	/**
 	 * Release Mount point list resources from {@link #DokanGetMountPointList}.

--- a/src/main/java/dev/dokan/dokan_java/Mountable.java
+++ b/src/main/java/dev/dokan/dokan_java/Mountable.java
@@ -27,7 +27,7 @@ public interface Mountable extends AutoCloseable {
      * @param threadCount        the number of threads spawned for processing filesystem calls
      * @param options            an {@link MaskValueSet} containing {@link MountOption}s
      */
-    void mount(Path mountPoint, String volumeName, int volumeSerialnumber, boolean blocking, long timeout, long allocationUnitSize, long sectorSize, String UNCName, short threadCount, MaskValueSet<MountOption> options);
+    void mount(Path mountPoint, String volumeName, int volumeSerialnumber, boolean blocking, @Unsigned int timeout, @Unsigned int allocationUnitSize, @Unsigned int sectorSize, String UNCName, @Unsigned short threadCount, MaskValueSet<MountOption> options);
 
     /**
      * Unmount this object.

--- a/src/main/java/dev/dokan/dokan_java/Unsigned.java
+++ b/src/main/java/dev/dokan/dokan_java/Unsigned.java
@@ -1,0 +1,17 @@
+package dev.dokan.dokan_java;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, TYPE_PARAMETER, TYPE_USE})
+public @interface Unsigned {
+
+}

--- a/src/main/java/dev/dokan/dokan_java/Unsigned.java
+++ b/src/main/java/dev/dokan/dokan_java/Unsigned.java
@@ -6,12 +6,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.ElementType.TYPE_PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
 
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(value = {METHOD, FIELD, PARAMETER, LOCAL_VARIABLE, TYPE_PARAMETER, TYPE_USE})
+//In Theory TYPE_USE should contain TYPE_PARAMETER,
+//but the documentation is so vague that I'm really not sure to be honest
+@Target(value = {TYPE_PARAMETER, TYPE_USE})
 public @interface Unsigned {
 
 }

--- a/src/main/java/dev/dokan/dokan_java/Unsigned.java
+++ b/src/main/java/dev/dokan/dokan_java/Unsigned.java
@@ -10,6 +10,182 @@ import static java.lang.annotation.ElementType.TYPE_PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 
 
+/**
+ * This annotation is used used to indicate that a value with an integer type or an integer type pointer refers to an <b>unsigned value.</b><br>
+ * In this case integers are <i>numbers without positions after decimal point.</i>
+ * (Java's Default integer types being {@code byte, short, int, long} and their corresponding wrappers.)
+ * <h1>Introduction</h1>
+ * Java stores integer types in <a href="https://en.wikipedia.org/wiki/Two%27s_complement">Two's complement-Representation.</a>
+ * Usually numbers represented as Two's complement use the Most-Significant-Bit (MSB) to store the sign of the number.
+ * If a field is annotated with <i>@Unsigned</i> this rule <b>does not apply!</b>
+ * Instead the MSB should be considered as part of the number itself, resulting in a doubled storage capacity of the field
+ * while <b>removing</b> the support for signed values (the field becomes unsigned and the value should only be interpreted as positive.)
+ * See this table as reference for the resulting differences when interpreting numbers:
+ * <table>
+ * <thead>
+ *   <tr>
+ *     <th>Signed value (Java Default)</th>
+ *     <th>Unsigned values (@Unsigned)</th>
+ *     <th>Bitmask (for a byte)</th>
+ *   </tr>
+ * </thead>
+ * <tbody>
+ *   <tr>
+ *     <td>0</td>
+ *     <td>0</td>
+ *     <td>0000 0000</td>
+ *   </tr>
+ *   <tr>
+ *     <td>1</td>
+ *     <td>1</td>
+ *     <td>0000 0001</td>
+ *   </tr>
+ *   <tr>
+ *     <td>2</td>
+ *     <td>2</td>
+ *     <td>0000 0010</td>
+ *   </tr>
+ *   <tr>
+ *     <td>64</td>
+ *     <td>64</td>
+ *     <td>0100 0000</td>
+ *   </tr>
+ *   <tr>
+ *     <td>-128</td>
+ *     <td>128</td>
+ *     <td>1000 0000</td>
+ *   </tr>
+ *   <tr>
+ *     <td>-127</td>
+ *     <td>129</td>
+ *     <td>1000 0001</td>
+ *   </tr>
+ *   <tr>
+ *     <td>-1</td>
+ *     <td>255</td>
+ *     <td>1111 1111</td>
+ *   </tr>
+ * </tbody>
+ * </table>
+ * <h1>Usage</h1>
+ * As Java only supports signed numbers, the correct interpretation and handling of unsigned numbers must be dealt with by the developer.
+ * Because of this it's <b>strongly recommended</b> to tag all values that are unsigned as such <b>by using this annotation.</b><br>
+ * <i>@Unsigned</i> is defined to {@link Target target} {@link java.lang.annotation.ElementType#TYPE_PARAMETER} and
+ * {@link java.lang.annotation.ElementType#TYPE_USE} and can therefore be applied to all usages of types (type contexts)
+ * and parameterized types respectively. See <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-9.html#jls-9.6.4.1">&sect9.6.4.1</a>
+ * and <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.11">&sect4.11</a> of "The Java&reg Language Specification" for
+ * further reference.<br>
+ * <br>
+ * At least the following cases ("minimum usage") should be annotated with <i>@Unsigned</i> to
+ * guarantee the best quality of code:
+ * <ul>
+ *     <li>Field declarations: {@code @Unsigned private final int index;}
+ *     <li>Local variable declarations: {@code @Unsigned int i;}
+ *     <li>Parameters: {@code public void remove(@Unsigned int index) {...}}
+ *     <li>Method return types: {@code public @Unsigned int getIndex() {...}}
+ * </ul><br>
+ * Additionally it's recommended to annotate <b>any</b> other usage of unsigned types ("advanced usage"),
+ * especially (but not limited to):
+ * <ul>
+ *     <li>Parameterized types: {@code List<@Unsigned Integer> indices = new ArrayList<>();}
+ *     <li>Casts: {@code Integer i = (@Unsigned Integer) uInt;}
+ *     <li>Type declarations: {@code public class @Unsigned UInt {...}}
+ *     <li>Extension/Implementation of unsigned types: {@code public class //@Unsigned// Index extends @Unsigned UInt {...}}
+ * </ul>
+ * <b>Note:</b> Contributions to the dokan-java project must annotate all usages of unsigned types (Minimum usage <b>and</b> advanced usage)
+ * with <i>@Unsigned.</i>
+ * <h1>Pitfalls</h1>
+ * If a field is annotated with <i>@Unsigned</i> developers should take extra care handling it as some unsafe operations may lead
+ * to unexpected results.
+ * An operation is considered <i>safe</i> if using it with unsigned values yields the same results as using it with signed numbers.
+ * ("An operation is safe if it can be used the same way when dealing with unsigned values as one would use it with signed numbers.")
+ * The following (inconclusive) table shows which operations are safe or unsafe and how operations can be dealt with alternatively.
+ * <table>
+ * <thead>
+ *   <tr>
+ *     <th>Operation</th>
+ *     <th>Safe/Unsafe</th>
+ *     <th>Recommended course of action</th>
+ *   </tr>
+ * </thead>
+ * <tbody>
+ *   <tr>
+ *     <td>Adding (+)</td>
+ *     <td>Safe</td>
+ *     <td></td>
+ *   </tr>
+ *   <tr>
+ *     <td>Subtracting (-)</td>
+ *     <td>Safe</td>
+ *     <td></td>
+ *   </tr>
+ *   <tr>
+ *     <td>Multiplication (*)</td>
+ *     <td>Safe</td>
+ *     <td></td>
+ *   </tr>
+ *   <tr>
+ *     <td>Division (/)</td>
+ *     <td>Unsafe</td>
+ *     <td>{@link UnsignedNumbers#divideUnsigned(int, int)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>Remainder/Modulo</td>
+ *     <td>Unsafe</td>
+ *     <td>{@link UnsignedNumbers#remainderUnsigned(int, int)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>Comparision (%)</td>
+ *     <td>Unsafe</td>
+ *     <td>{@link UnsignedNumbers#compareUnsigned(int, int)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>Printing</td>
+ *     <td>Unsafe</td>
+ *     <td>{@link UnsignedNumbers#toUnsignedString(int)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>Downcasting</td>
+ *     <td>Safe</td>
+ *     <td>{@link UnsignedNumbers#toUnsignedInt(long)}</td>
+ *   </tr>
+ *   <tr>
+ *     <td>Upcasting</td>
+ *     <td>Unsafe</td>
+ *     <td>{@link UnsignedNumbers#toUnsignedInt(short)}</td>
+ *   </tr>
+ * </tbody>
+ * </table>
+ * <b>Note:</b> Operations that require two numbers (e.g. addition, subtraction) should <b>never</b> be used with a signed
+ * and an unsigned number as arguments, even if the operation is usually considered safe.
+ * Doing so can result in heavy computational errors, as seen here:<br>
+ * <br>
+ * {@code //Don't do this:}<br>
+ * {@code byte a = 64; //0100 0000}<br>
+ * {@code @Unsigned byte b = 64; //0100 0000}<br>
+ * {@code byte c = a + b; //0100 0000 + 0100 0000}<br>
+ * {@code //--> c = -128; //1000 0000}<br>
+ * <br>
+ * This is a problem for the following reason: Before the addition the status (signed/unsigned) of
+ * <i>a</i> and <i>b</i> didn't matter (in fact they were equal). As soon as the value exceeds 127 the developer needs to decide
+ * whether <i>c</i> is signed or unsigned.<br>
+ * If <i>c</i> is unsigned all future users of <i>c</i> must take care that they
+ * interpret it correctly. Also <i>a</i> comes from a signed context and could be negative.
+ * If <i>a's</i> MSB is set to indicate a negative value any computation that considers <i>a</i> unsigned must be wrong
+ * as it would interpret <i>a</i> as a big positive number instead of a negative number.<br>
+ * If <i>c</i> is interpreted as signed, the computation is plain wrong (64 + 64 is not -128) because it leads to a number-overflow.<br>
+ * <br>
+ * {@code //Instead do this:}<br>
+ * {@code byte a = 64;}<br>
+ * {@code @Unsigned byte b = 64;}<br>
+ * {@code short s = UnsignedNumbers.toUnsignedShort(b);}<br>
+ * {@code short c = s + a;}<br>
+ * {@code //--> c = 128;}<br>
+ *
+ * @author <a href="https://github.com/JaniruTEC">JaniruTEC</a>
+ * @see UnsignedNumbers
+ * @since 2.0
+ */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 //In Theory TYPE_USE should contain TYPE_PARAMETER,

--- a/src/main/java/dev/dokan/dokan_java/UnsignedNumbers.java
+++ b/src/main/java/dev/dokan/dokan_java/UnsignedNumbers.java
@@ -160,4 +160,64 @@ public class UnsignedNumbers {
     public static int compareUnsigned(long x, long y) {
         return Long.compareUnsigned(x, y);
     }
+
+    /////////////////////////////////////////////////////////
+    ////////////////////// Conversions //////////////////////
+    /////////////////////////////////////////////////////////
+
+    //////////////////////    byte     //////////////////////
+
+    public static @Unsigned byte toUnsignedByte(@Unsigned short value) {
+        return (byte) value;
+    }
+
+    public static @Unsigned byte toUnsignedByte(@Unsigned int value) {
+        return (byte) value;
+    }
+
+    public static @Unsigned byte toUnsignedByte(@Unsigned long value) {
+        return (byte) value;
+    }
+
+    //////////////////////    short    //////////////////////
+
+    public static @Unsigned short toUnsignedShort(@Unsigned byte value) {
+        return (short) (((short) value) & BYTE_MASK);
+    }
+
+    public static @Unsigned short toUnsignedShort(@Unsigned int value) {
+        return (short) value;
+    }
+
+    public static @Unsigned short toUnsignedShort(@Unsigned long value) {
+        return (short) value;
+    }
+
+    //////////////////////     int     //////////////////////
+
+    public static @Unsigned int toUnsignedInt(@Unsigned byte value) {
+        return ((int) value) & BYTE_MASK;
+    }
+
+    public static @Unsigned int toUnsignedInt(@Unsigned short value) {
+        return ((int) value) & SHORT_MASK;
+    }
+
+    public static @Unsigned int toUnsignedInt(@Unsigned long value) {
+        return (int) value;
+    }
+
+    //////////////////////    long     //////////////////////
+
+    public static @Unsigned long toUnsignedLong(@Unsigned byte value) {
+        return ((long) value) & BYTE_MASK;
+    }
+
+    public static @Unsigned long toUnsignedLong(@Unsigned short value) {
+        return ((long) value) & SHORT_MASK;
+    }
+
+    public static @Unsigned long toUnsignedLong(@Unsigned int value) {
+        return ((long) value) & INT_MASK;
+    }
 }

--- a/src/main/java/dev/dokan/dokan_java/UnsignedNumbers.java
+++ b/src/main/java/dev/dokan/dokan_java/UnsignedNumbers.java
@@ -19,4 +19,145 @@ public class UnsignedNumbers {
         return Long.toUnsignedString(value);
     }
 
+    /**
+     * Convenience method that stands in for the missing method {@code Byte#divideUnsigned(byte, byte)}.<br>
+     * This method was inspired by {@link Integer#divideUnsigned(int, int) the method of the same in Integer}<br>
+     * <br>
+     * <b>Description copied from {@link Integer#divideUnsigned(int, int)}</b><br>
+     * Returns the unsigned quotient of dividing the first argument by
+     * the second where each argument and the result is interpreted as
+     * an unsigned value.
+     *
+     * <p>Note that in two's complement arithmetic, the three other
+     * basic arithmetic operations of add, subtract, and multiply are
+     * bit-wise identical if the two operands are regarded as both
+     * being signed or both being unsigned.  Therefore separate {@code
+     * addUnsigned}, etc. methods are not provided.
+     *
+     * @param dividend the value to be divided
+     * @param divisor the value doing the dividing
+     * @return the unsigned quotient of the first argument divided by
+     * the second argument
+     * @see #remainderUnsigned
+     * @since 1.8
+     *
+     * @see Integer#divideUnsigned(int, int)
+     */
+    public static @Unsigned byte divideUnsigned(@Unsigned byte dividend, @Unsigned byte divisor) {
+        return (byte) (Byte.toUnsignedInt(dividend) / Byte.toUnsignedInt(divisor));
+    }
+
+    /**
+     * Convenience method that stands in for the missing method {@code Short#divideUnsigned(short, short)}.<br>
+     * This method was inspired by {@link Integer#divideUnsigned(int, int) the method of the same in Integer}<br>
+     * <br>
+     * <b>Description copied from {@link Integer#divideUnsigned(int, int)}</b><br>
+     * Returns the unsigned quotient of dividing the first argument by
+     * the second where each argument and the result is interpreted as
+     * an unsigned value.
+     *
+     * <p>Note that in two's complement arithmetic, the three other
+     * basic arithmetic operations of add, subtract, and multiply are
+     * bit-wise identical if the two operands are regarded as both
+     * being signed or both being unsigned.  Therefore separate {@code
+     * addUnsigned}, etc. methods are not provided.
+     *
+     * @param dividend the value to be divided
+     * @param divisor the value doing the dividing
+     * @return the unsigned quotient of the first argument divided by
+     * the second argument
+     * @see #remainderUnsigned
+     * @since 1.8
+     *
+     * @see Integer#divideUnsigned(int, int)
+     */
+    public static @Unsigned short divideUnsigned(@Unsigned short dividend, @Unsigned short divisor) {
+        return (short) (Short.toUnsignedInt(dividend) / Short.toUnsignedInt(divisor));
+    }
+
+    /**
+     * Convenience method that delegates to {@link Integer#divideUnsigned(int, int)}.<br>
+     * <br>
+     * <b>Description copied from {@link Integer#divideUnsigned(int, int)}</b><br>
+     * Returns the unsigned quotient of dividing the first argument by
+     * the second where each argument and the result is interpreted as
+     * an unsigned value.
+     *
+     * <p>Note that in two's complement arithmetic, the three other
+     * basic arithmetic operations of add, subtract, and multiply are
+     * bit-wise identical if the two operands are regarded as both
+     * being signed or both being unsigned.  Therefore separate {@code
+     * addUnsigned}, etc. methods are not provided.
+     *
+     * @param dividend the value to be divided
+     * @param divisor the value doing the dividing
+     * @return the unsigned quotient of the first argument divided by
+     * the second argument
+     * @see #remainderUnsigned
+     * @since 1.8
+     *
+     * @see Integer#divideUnsigned(int, int)
+     */
+    public static @Unsigned int divideUnsigned(@Unsigned int dividend, @Unsigned int divisor) {
+        return Integer.divideUnsigned(dividend, divisor);
+    }
+
+    /**
+     * Convenience method that delegates to {@link Long#divideUnsigned(long, long)}.<br>
+     * <br>
+     * <b>Description copied from {@link Long#divideUnsigned(long, long)}</b><br>
+     * Returns the unsigned quotient of dividing the first argument by
+     * the second where each argument and the result is interpreted as
+     * an unsigned value.
+     *
+     * <p>Note that in two's complement arithmetic, the three other
+     * basic arithmetic operations of add, subtract, and multiply are
+     * bit-wise identical if the two operands are regarded as both
+     * being signed or both being unsigned.  Therefore separate {@code
+     * addUnsigned}, etc. methods are not provided.
+     *
+     * @param dividend the value to be divided
+     * @param divisor the value doing the dividing
+     * @return the unsigned quotient of the first argument divided by
+     * the second argument
+     * @see #remainderUnsigned
+     * @since 1.8
+     *
+     * @see Long#divideUnsigned(long, long)
+     */
+    public static @Unsigned long divideUnsigned(@Unsigned long dividend, @Unsigned long divisor) {
+        return Long.divideUnsigned(dividend, divisor);
+    }
+
+    public static @Unsigned byte remainderUnsigned(@Unsigned byte dividend, @Unsigned byte divisor) {
+        return (byte) (Byte.toUnsignedInt(dividend) % Byte.toUnsignedInt(divisor));
+    }
+
+    public static @Unsigned short remainderUnsigned(@Unsigned short dividend, @Unsigned short divisor) {
+        return (short) (Short.toUnsignedInt(dividend) % Short.toUnsignedInt(divisor));
+    }
+
+    public static @Unsigned int remainderUnsigned(@Unsigned int dividend, @Unsigned int divisor) {
+        return Integer.remainderUnsigned(dividend, divisor);
+    }
+
+    public static @Unsigned long remainderUnsigned(@Unsigned long dividend, @Unsigned long divisor) {
+        return Long.remainderUnsigned(dividend, divisor);
+    }
+
+    public static int compareUnsigned(byte x, byte y) {
+        return Byte.compareUnsigned(x, y);
+    }
+
+    public static int compareUnsigned(short x, short y) {
+        return Short.compareUnsigned(x, y);
+    }
+
+    public static int compareUnsigned(int x, int y) {
+        return Integer.compareUnsigned(x, y);
+    }
+
+    public static int compareUnsigned(long x, long y) {
+        return Long.compareUnsigned(x, y);
+    }
 }

--- a/src/main/java/dev/dokan/dokan_java/UnsignedNumbers.java
+++ b/src/main/java/dev/dokan/dokan_java/UnsignedNumbers.java
@@ -1,0 +1,22 @@
+package dev.dokan.dokan_java;
+
+
+public class UnsignedNumbers {
+
+    public static String toUnsignedString(@Unsigned byte value) {
+        return toUnsignedString(Byte.toUnsignedInt(value));
+    }
+
+    public static String toUnsignedString(@Unsigned short value) {
+        return toUnsignedString(Short.toUnsignedInt(value));
+    }
+
+    public static String toUnsignedString(@Unsigned int value) {
+        return Integer.toUnsignedString(value);
+    }
+
+    public static String toUnsignedString(@Unsigned long value) {
+        return Long.toUnsignedString(value);
+    }
+
+}

--- a/src/main/java/dev/dokan/dokan_java/UnsignedNumbers.java
+++ b/src/main/java/dev/dokan/dokan_java/UnsignedNumbers.java
@@ -3,6 +3,10 @@ package dev.dokan.dokan_java;
 
 public class UnsignedNumbers {
 
+    private static final short BYTE_MASK = 0xff;
+    private static final int SHORT_MASK = 0xffff;
+    private static final long INT_MASK = 0xffffff;
+
     public static String toUnsignedString(@Unsigned byte value) {
         return toUnsignedString(Byte.toUnsignedInt(value));
     }

--- a/src/main/java/dev/dokan/dokan_java/examples/DirListingFileSystem.java
+++ b/src/main/java/dev/dokan/dokan_java/examples/DirListingFileSystem.java
@@ -10,6 +10,7 @@ import dev.dokan.dokan_java.DokanFileSystemStub;
 import dev.dokan.dokan_java.DokanOperations;
 import dev.dokan.dokan_java.DokanUtils;
 import dev.dokan.dokan_java.FileSystemInformation;
+import dev.dokan.dokan_java.Unsigned;
 import dev.dokan.dokan_java.constants.microsoft.CreateDisposition;
 import dev.dokan.dokan_java.constants.microsoft.CreateOption;
 import dev.dokan.dokan_java.constants.microsoft.NtStatuses;
@@ -93,7 +94,7 @@ public class DirListingFileSystem extends DokanFileSystemStub {
             }
         }
 
-        long val = this.handleHandler.incrementAndGet();
+        @Unsigned long val = this.handleHandler.incrementAndGet();
         if (val == 0) {
             val = this.handleHandler.incrementAndGet();
         }
@@ -135,7 +136,7 @@ public class DirListingFileSystem extends DokanFileSystemStub {
         if (attr.fileKey() != null) {
             index = (long) attr.fileKey();
         }
-        int fileAttr = 0;
+        @Unsigned int fileAttr = 0;
         fileAttr |= attr.isArchive() ? WinNT.FILE_ATTRIBUTE_ARCHIVE : 0;
         fileAttr |= attr.isSystem() ? WinNT.FILE_ATTRIBUTE_SYSTEM : 0;
         fileAttr |= attr.isHidden() ? WinNT.FILE_ATTRIBUTE_HIDDEN : 0;

--- a/src/main/java/dev/dokan/dokan_java/structure/ByHandleFileInformation.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/ByHandleFileInformation.java
@@ -7,6 +7,7 @@ import com.sun.jna.platform.win32.WinNT;
 import dev.dokan.dokan_java.DokanOperations;
 import dev.dokan.dokan_java.DokanUtils;
 import dev.dokan.dokan_java.Unsigned;
+import dev.dokan.dokan_java.UnsignedNumbers;
 import dev.dokan.dokan_java.constants.microsoft.FileAttribute;
 import dev.dokan.dokan_java.masking.MaskValueSet;
 
@@ -104,7 +105,7 @@ public class ByHandleFileInformation extends Structure implements Structure.ByRe
         this(null, null, null);
     }
 
-    public ByHandleFileInformation(Path filePath, int attrs, FileTime creationTime, FileTime lastAccessTime, FileTime lastWriteTime, int volumeSerialNumber, long fileSize, long fileIndex) {
+    public ByHandleFileInformation(Path filePath, @Unsigned int attrs, FileTime creationTime, FileTime lastAccessTime, FileTime lastWriteTime, @Unsigned int volumeSerialNumber, @Unsigned long fileSize, @Unsigned long fileIndex) {
         this.filePath = filePath;
         this.dwFileAttributes = attrs;
         this.setTimes(creationTime.toMillis(), lastAccessTime.toMillis(), lastWriteTime.toMillis());
@@ -113,7 +114,7 @@ public class ByHandleFileInformation extends Structure implements Structure.ByRe
         this.dwVolumeSerialNumber = volumeSerialNumber;
     }
 
-    public ByHandleFileInformation(Path filePath, MaskValueSet<FileAttribute> attrs, FileTime creationTime, FileTime lastAccessTime, FileTime lastWriteTime, int volumeSerialNumber, long fileSize, long fileIndex) {
+    public ByHandleFileInformation(Path filePath, MaskValueSet<FileAttribute> attrs, FileTime creationTime, FileTime lastAccessTime, FileTime lastWriteTime, @Unsigned int volumeSerialNumber, @Unsigned long fileSize, @Unsigned long fileIndex) {
         this.filePath = filePath;
         this.dwFileAttributes = attrs.intValue();
         this.setTimes(creationTime.toMillis(), lastAccessTime.toMillis(), lastWriteTime.toMillis());
@@ -196,14 +197,14 @@ public class ByHandleFileInformation extends Structure implements Structure.ByRe
      *
      * @param sizeToSet the new size of the file
      */
-    public void setFileSize(final long sizeToSet) {
+    public void setFileSize(@Unsigned final long sizeToSet) {
         this.fileSize = sizeToSet;
         final WinNT.LARGE_INTEGER largeInt = new WinNT.LARGE_INTEGER(sizeToSet);
         this.nFileSizeHigh = largeInt.getHigh().intValue();
         this.nFileSizeLow = largeInt.getLow().intValue();
     }
 
-    protected final void setSizesExplicit(final long size, final int sizeHigh, final int sizeLow) {
+    protected final void setSizesExplicit(@Unsigned final long size, @Unsigned final int sizeHigh, @Unsigned final int sizeLow) {
         this.fileSize = size;
         this.nFileSizeHigh = sizeHigh;
         this.nFileSizeLow = sizeLow;
@@ -213,14 +214,14 @@ public class ByHandleFileInformation extends Structure implements Structure.ByRe
         return this.fileSize;
     }
 
-    public void setIndex(final long index) {
+    public void setIndex(@Unsigned final long index) {
         this.fileIndex = index;
         final WinNT.LARGE_INTEGER largeInt = new WinNT.LARGE_INTEGER(index);
         this.nFileIndexHigh = largeInt.getHigh().intValue();
         this.nFileIndexLow = largeInt.getLow().intValue();
     }
 
-    protected void setIndexExplicit(final long index, final int indexHigh, final int indexLow) {
+    protected void setIndexExplicit(@Unsigned final long index, @Unsigned final int indexHigh, @Unsigned final int indexLow) {
         this.fileIndex = index;
         this.nFileIndexHigh = indexHigh;
         this.nFileIndexLow = indexLow;
@@ -252,6 +253,17 @@ public class ByHandleFileInformation extends Structure implements Structure.ByRe
 
     @Override
     public String toString() {
-        return "ByHandleFileInfo(filePath=" + this.filePath + ", fileIndex=" + this.fileIndex + ", fileSize=" + this.fileSize + ", nFileIndexHigh=" + this.nFileIndexHigh + ", nFileIndexLow=" + this.nFileIndexLow + ", dwFileAttributes=" + this.dwFileAttributes + ", ftCreationTime=" + this.ftCreationTime + ", ftLastAccessTime=" + this.ftLastAccessTime + ", ftLastWriteTime=" + this.ftLastWriteTime + ", nFileSizeHigh=" + this.nFileSizeHigh + ", nFileSizeLow=" + this.nFileSizeLow + ", dwVolumeSerialNumber=" + this.dwVolumeSerialNumber + ", nNumberOfLinks=" + this.nNumberOfLinks + ")";
+        return String.format("ByHandleFileInfo(filePath=%s, fileIndex=%s, fileSize=%s, nFileIndexHigh=%s, nFileIndexLow=%s, dwFileAttributes=%s, ftCreationTime=%s, ftLastAccessTime=%s, ftLastWriteTime=%s, nFileSizeHigh=%s, nFileSizeLow=%s, dwVolumeSerialNumber=%s, nNumberOfLinks=%s)",
+                this.filePath,
+                UnsignedNumbers.toUnsignedString(this.fileIndex),
+                UnsignedNumbers.toUnsignedString(this.fileSize),
+                UnsignedNumbers.toUnsignedString(this.nFileIndexHigh),
+                UnsignedNumbers.toUnsignedString(this.nFileIndexLow),
+                UnsignedNumbers.toUnsignedString(this.dwFileAttributes),
+                this.ftCreationTime, this.ftLastAccessTime, this.ftLastWriteTime,
+                UnsignedNumbers.toUnsignedString(this.nFileSizeHigh),
+                UnsignedNumbers.toUnsignedString(this.nFileSizeLow),
+                UnsignedNumbers.toUnsignedString(this.dwVolumeSerialNumber),
+                UnsignedNumbers.toUnsignedString(this.nNumberOfLinks));
     }
 }

--- a/src/main/java/dev/dokan/dokan_java/structure/ByHandleFileInformation.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/ByHandleFileInformation.java
@@ -1,12 +1,13 @@
 package dev.dokan.dokan_java.structure;
 
-import dev.dokan.dokan_java.DokanOperations;
-import dev.dokan.dokan_java.DokanUtils;
-import dev.dokan.dokan_java.constants.microsoft.FileAttribute;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.WinBase;
 import com.sun.jna.platform.win32.WinBase.FILETIME;
 import com.sun.jna.platform.win32.WinNT;
+import dev.dokan.dokan_java.DokanOperations;
+import dev.dokan.dokan_java.DokanUtils;
+import dev.dokan.dokan_java.Unsigned;
+import dev.dokan.dokan_java.constants.microsoft.FileAttribute;
 import dev.dokan.dokan_java.masking.MaskValueSet;
 
 import java.nio.file.Path;
@@ -39,6 +40,7 @@ public class ByHandleFileInformation extends Structure implements Structure.ByRe
      * The file attributes of a file. For possible values and their descriptions, see File Attribute Constants. The FILE_ATTRIBUTE_SPARSE_FILE attribute on the file is set if any of the streams of the file have ever been
      * sparse.
      */
+    @Unsigned
     public int dwFileAttributes;
 
     /**
@@ -61,31 +63,37 @@ public class ByHandleFileInformation extends Structure implements Structure.ByRe
     /**
      * The serial number of the volume that contains a file.
      */
+    @Unsigned
     public int dwVolumeSerialNumber;
 
     /**
      * The high-order DWORD value of the file size, in bytes. This value is zero unless the file size is greater than MAXDWORD. The size of the file is equal to (nFileSizeHigh * (MAXDWORD+1)) + nFileSizeLow.
      */
+    @Unsigned
     public int nFileSizeHigh;
 
     /**
      * The low-order DWORD value of the file size, in bytes.
      */
+    @Unsigned
     public int nFileSizeLow;
 
     /**
      * The high-order DWORD value of the file size, in bytes. This value is zero unless the file size is greater than MAXDWORD. The size of the file is equal to (nFileSizeHigh* (MAXDWORD+1)) + nFileSizeLow.
      */
+    @Unsigned
     public int nFileIndexHigh;
 
     /**
      * The low-order DWORD value of the file size, in bytes.
      */
+    @Unsigned
     public int nFileIndexLow;
 
     /**
      * The number of links to this file. For the FAT file system this member is always 1. For the NTFS file system, it can be more than 1.
      */
+    @Unsigned
     public int nNumberOfLinks = 1;
 
     private Path filePath;

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanAccessState.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanAccessState.java
@@ -46,7 +46,7 @@ public class DokanAccessState extends Structure {
 	 * A driver can check for the traverse access flag (TOKEN_HAS_TRAVERSE_PRIVILEGE).
 	 * For more information about how to check for traverse access, see <a href="https://docs.microsoft.com/windows-hardware/drivers/ifs/checking-for-traverse-privilege-on-irp-mj-create">Check for Traverse Privilege on IRP_MJ_CREATE</a>.
 	 * A driver can also check for the TOKEN_IS_RESTRICTED flag.
-	 * These flags are defined in Ntifs.h.
+	 * These flags are defined in ntifs.h.
 	 */
 	@Unsigned
 	public int Flags;

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanAccessState.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanAccessState.java
@@ -1,9 +1,9 @@
 package dev.dokan.dokan_java.structure;
 
 
-import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.WinNT;
+import dev.dokan.dokan_java.Unsigned;
 
 import java.util.Arrays;
 import java.util.List;
@@ -48,6 +48,7 @@ public class DokanAccessState extends Structure {
 	 * A driver can also check for the TOKEN_IS_RESTRICTED flag.
 	 * These flags are defined in Ntifs.h.
 	 */
+	@Unsigned
 	public int Flags;
 
 	/**
@@ -55,17 +56,20 @@ public class DokanAccessState extends Structure {
 	 * A driver uses this member to determine if the Windows security system can grant access.
 	 * If access can be granted, the driver updates the PreviouslyGrantedAccess and RemainingDesiredAccess members accordingly.
 	 */
+	@Unsigned
 	public int RemainingDesiredAccess;
 
 	/**
 	 * An ACCESS_MASK type that specifies the information about access that has already been granted to the caller of one of the <a href="https://docs.microsoft.com/previous-versions/windows/hardware/drivers/ff563711(v=vs.85)">Security Reference Monitor Routines</a>
 	 * The Windows security system grants certain rights based on the privileges of the caller, such as traverse right (the ability to traverse through a directory as part of opening a subdirectory or file).
 	 */
+	@Unsigned
 	public int PreviouslyGrantedAccess;
 
 	/**
 	 * An ACCESS_MASK type that contains the original access rights that were requested by the caller.
 	 */
+	@Unsigned
 	public int OriginalDesiredAccess;
 
 	/**

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
@@ -93,7 +93,9 @@ public class DokanControl extends Structure implements Structure.ByReference {
     public static List<DokanControl> getDokanControlList(Pointer start, @Unsigned int length) { //TODO Relocate
         List<DokanControl> list = new ArrayList<>();
 
-        assert !(length < 0);
+        if(length < 0) {
+            throw new AssertionError(String.format("Illegal length: %s (%d)", Integer.toUnsignedString(length), length));
+        }
         if (length != 0) {
             long offset = 0;
             for(int i = 0; i < length; i++) {

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
@@ -1,5 +1,6 @@
 package dev.dokan.dokan_java.structure;
 
+
 import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
@@ -21,6 +22,7 @@ public class DokanControl extends Structure implements Structure.ByReference {
     /**
      * File System Type
      */
+    @Unsigned
     public int Type;
 
     /**
@@ -46,6 +48,7 @@ public class DokanControl extends Structure implements Structure.ByReference {
     /**
      * Session ID of calling process
      */
+    @Unsigned
     public int SessionId;
 
     public DokanControl(Pointer p) {

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
@@ -77,7 +77,7 @@ public class DokanControl extends Structure implements Structure.ByReference {
     }
 
     /**
-     * Creates a java {@link List} of {@link DokanControl} strcutures given the pointer returned by NativeMethods#DokanGetMountPointList(boolean, LongByReference).<br>
+     * Creates a java {@link List} of {@link DokanControl} structures given the pointer returned by NativeMethods#DokanGetMountPointList(boolean, LongByReference).<br>
      * <br>
      * <b>Implementation note:</b><br>
      * Length is an unsigned 32-bit int. Java only supports arrays and lists up to an index size of 2<sup>31</sup>-1 ({@link Integer#MAX_VALUE Integer.MAX_VALUE}).

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
@@ -77,7 +77,14 @@ public class DokanControl extends Structure implements Structure.ByReference {
     }
 
     /**
-     * Creates a java {@link List} of {@link DokanControl} strcutures given the pointer returned by NativeMethods#DokanGetMountPointList(boolean, LongByReference).
+     * Creates a java {@link List} of {@link DokanControl} strcutures given the pointer returned by NativeMethods#DokanGetMountPointList(boolean, LongByReference).<br>
+     * <br>
+     * <b>Implementation note:</b><br>
+     * Length is an unsigned 32-bit int. Java only supports arrays and lists up to an index size of 2<sup>31</sup>-1 ({@link Integer#MAX_VALUE Integer.MAX_VALUE}).
+     * A list that exceeds this size is unrealistic (it would need at least 2 GB of space, even if it only stored unique Byte-Objects).
+     * Any value that exceeds {@link Integer#MAX_VALUE Integer.MAX_VALUE}, has it's 32nd bit set (at least when using Two's complement for storing it).
+     * The 32nd bit defines the sign of a java int, therefore a {@code length < 0} indicates that this threshold has been reached.
+     * In this case the application crashes ("fail-fast") to allow someone to take care of this issue.
      *
      * @param start  the initial pointer returned by the native method
      * @param length the number of elements in the array. Also acquired with the native method call.
@@ -85,17 +92,7 @@ public class DokanControl extends Structure implements Structure.ByReference {
      */
     public static List<DokanControl> getDokanControlList(Pointer start, @Unsigned int length) { //TODO Relocate
         List<DokanControl> list = new ArrayList<>();
-        /*
-         * Let's do the math:
-         * A list that uses an unsigned int (32 bit) as index could save up to 2^32 objects.
-         * Even if it only saved one byte in each entry (not accounting for the actual overhead of the entries themselves),
-         * that would be 2^32 bytes = 4 GB for that list alone!
-         * If the list of active Dokan MountPoints exceeds 2^31 (signed int) entries, we probably have other problems.
-         *
-         * But let's assume that this could still happen:
-         * In this case we want the application to crash so that someone else can fix that nonsense.
-         * "assert" seems like a good choice for this case (for once).
-         */
+
         assert !(length < 0);
         if (length != 0) {
             long offset = 0;

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
@@ -1,5 +1,6 @@
 package dev.dokan.dokan_java.structure;
 
+import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
@@ -20,7 +21,7 @@ public class DokanControl extends Structure implements Structure.ByReference {
     /**
      * File System Type
      */
-    public long Type;
+    public int Type;
 
     /**
      * Mount point. Can be "M:\" (drive letter) or "C:\mount\dokan" (path in NTFS)
@@ -45,16 +46,15 @@ public class DokanControl extends Structure implements Structure.ByReference {
     /**
      * Session ID of calling process
      */
-    public long SessionId;
+    public int SessionId;
 
     public DokanControl(Pointer p) {
         this(p, 0);
     }
 
-    public DokanControl(Pointer p, long offset) {
+    public DokanControl(Pointer p, long currentOffset) {
         super(p);
-        long currentOffset = offset;
-        this.Type = p.getLong(currentOffset);
+        this.Type = p.getInt(currentOffset);
         currentOffset += NativeLong.SIZE;
         this.MountPoint = p.getCharArray(currentOffset, WinNT.MAX_PATH);
         currentOffset += WinNT.MAX_PATH * 2;
@@ -63,8 +63,8 @@ public class DokanControl extends Structure implements Structure.ByReference {
         this.DeviceName = p.getCharArray(currentOffset, 64);
         currentOffset += 64 * 2;
         this.DeviceObject = new Pointer(p.getLong(currentOffset));
-        currentOffset += NativeLong.SIZE;
-        this.SessionId = p.getLong(currentOffset);
+        currentOffset += Native.POINTER_SIZE;
+        this.SessionId = p.getInt(currentOffset);
     }
 
 

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanControl.java
@@ -25,7 +25,7 @@ public class DokanControl extends Structure implements Structure.ByReference {
     /**
      * Mount point. Can be "M:\" (drive letter) or "C:\mount\dokan" (path in NTFS)
      */
-    public char[] MountPoint = new char[260];
+    public char[] MountPoint = new char[WinNT.MAX_PATH];
 
     /**
      * UNC name used for network volume
@@ -95,9 +95,11 @@ public class DokanControl extends Structure implements Structure.ByReference {
          */
         assert !(length < 0);
         if (length != 0) {
-            list.add(new DokanControl(start));
-            for (int i = 1; i < length; i++) {
-                list.add(new DokanControl(start, i * list.get(0).size()));
+            long offset = 0;
+            for(int i = 0; i < length; i++) {
+                DokanControl control = new DokanControl(start, offset);
+                list.add(control);
+                offset += control.size();
             }
         }
         return list;

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanFileInfo.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanFileInfo.java
@@ -1,8 +1,9 @@
 package dev.dokan.dokan_java.structure;
 
+import com.sun.jna.Structure;
 import dev.dokan.dokan_java.DokanNativeMethods;
 import dev.dokan.dokan_java.DokanOperations;
-import com.sun.jna.Structure;
+import dev.dokan.dokan_java.Unsigned;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,6 +19,7 @@ public class DokanFileInfo extends Structure implements Structure.ByReference {
      * Context that can be used to carry information between operation. The context can carry whatever type like {@link com.sun.jna.platform.win32.WinNT.HANDLE}, {@link Structure}, {@link com.sun.jna.ptr.IntByReference},
      * {@link com.sun.jna.Pointer} that will help the implementation understand the request context of the event.
      */
+    @Unsigned
     public long Context;
 
     /**
@@ -28,6 +30,7 @@ public class DokanFileInfo extends Structure implements Structure.ByReference {
     /**
      * Reserved. Used internally by Dokan library. Never modify.
      */
+    @Unsigned
     public long DokanContext;
 
     /**
@@ -53,6 +56,7 @@ public class DokanFileInfo extends Structure implements Structure.ByReference {
     /**
      * Process ID for the thread that originally requested a given I/O operation.
      */
+    @Unsigned
     public int ProcessId;
 
     /**

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanFileInfo.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanFileInfo.java
@@ -1,9 +1,11 @@
 package dev.dokan.dokan_java.structure;
 
+
 import com.sun.jna.Structure;
 import dev.dokan.dokan_java.DokanNativeMethods;
 import dev.dokan.dokan_java.DokanOperations;
 import dev.dokan.dokan_java.Unsigned;
+import dev.dokan.dokan_java.UnsignedNumbers;
 
 import java.util.Arrays;
 import java.util.List;
@@ -103,7 +105,17 @@ public class DokanFileInfo extends Structure implements Structure.ByReference {
 
     @Override
     public String toString() {
-        return "DokanFileInfo(Context=" + this.Context + ", DokanContext=" + this.DokanContext + ", DokanOpts=" + this.DokanOpts + ", ProcessId=" + this.ProcessId + ", IsDirectory=" + this.IsDirectory + ", DeleteOnClose=" + this.DeleteOnClose + ", PagingIo=" + this.PagingIo + ", SynchronousIo=" + this.SynchronousIo + ", Nocache=" + this.Nocache + ", WriteToEndOfFile=" + this.WriteToEndOfFile + ")";
+        return String.format("DokanFileInfo(Context=%s, DokanContext=%s, DokanOpts=%s, ProcessId=%s, IsDirectory=%s/%s, DeleteOnClose=%s/%s, PagingIo=%s/%s, SynchronousIo=%s/%s, Nocache=%s/%s, WriteToEndOfFile=%s/%s)",
+                UnsignedNumbers.toUnsignedString(this.Context),
+                UnsignedNumbers.toUnsignedString(this.DokanContext),
+                this.DokanOpts,
+                UnsignedNumbers.toUnsignedString(this.ProcessId),
+                this.IsDirectory, isDirectory(),
+                this.DeleteOnClose, deleteOnClose(),
+                this.PagingIo, pagingIo(),
+                this.SynchronousIo, synchronousIo(),
+                this.Nocache, noCache(),
+                this.WriteToEndOfFile, writeToEndOfFile());
     }
 
 }

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanIOSecurityContext.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanIOSecurityContext.java
@@ -3,6 +3,7 @@ package dev.dokan.dokan_java.structure;
 
 import com.sun.jna.Structure;
 import com.sun.jna.WString;
+import dev.dokan.dokan_java.Unsigned;
 
 
 /**
@@ -23,6 +24,7 @@ public class DokanIOSecurityContext extends Structure implements Structure.ByRef
 	/**
 	 * An ACCESS_MASK value that expresses the access rights that are requested in the IRP_MJ_CREATE request.
 	 */
+	@Unsigned
 	public int DesiredAccess;
 
 }

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanOptions.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanOptions.java
@@ -1,10 +1,11 @@
 package dev.dokan.dokan_java.structure;
 
 
-import dev.dokan.dokan_java.DokanNativeMethods;
-import dev.dokan.dokan_java.constants.dokany.MountOption;
 import com.sun.jna.Structure;
 import com.sun.jna.WString;
+import dev.dokan.dokan_java.DokanNativeMethods;
+import dev.dokan.dokan_java.Unsigned;
+import dev.dokan.dokan_java.constants.dokany.MountOption;
 import dev.dokan.dokan_java.masking.MaskValueSet;
 
 import java.util.Arrays;
@@ -53,23 +54,23 @@ public class DokanOptions extends Structure implements Structure.ByReference {
 	/**
 	 * Max timeout in milliseconds of each request before Dokan gives up to wait events to complete.
 	 */
-	public long Timeout;
+	public int Timeout;
 
 	/**
 	 * Allocation Unit Size of the volume. This will affect the file size.
 	 */
-	public long AllocationUnitSize;
+	public int AllocationUnitSize;
 
 	/**
 	 * Sector Size of the volume. This will affect then file size.
 	 */
-	public long SectorSize;
+	public int SectorSize;
 
 	public DokanOptions() {
 
 	}
 
-	public DokanOptions(final String mountPoint, final short threadCount, final MaskValueSet<MountOption> mountOptions, final String uncName, final long timeout, final long allocationUnitSize, final long sectorSize) {
+	public DokanOptions(String mountPoint, @Unsigned short threadCount, MaskValueSet<MountOption> mountOptions, String uncName, @Unsigned int timeout, @Unsigned int allocationUnitSize, @Unsigned int sectorSize) {
 		MountPoint = new WString(mountPoint);
 		ThreadCount = threadCount;
 		Options = mountOptions.intValue();

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanOptions.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanOptions.java
@@ -5,6 +5,7 @@ import com.sun.jna.Structure;
 import com.sun.jna.WString;
 import dev.dokan.dokan_java.DokanNativeMethods;
 import dev.dokan.dokan_java.Unsigned;
+import dev.dokan.dokan_java.UnsignedNumbers;
 import dev.dokan.dokan_java.constants.dokany.MountOption;
 import dev.dokan.dokan_java.masking.MaskValueSet;
 
@@ -102,6 +103,16 @@ public class DokanOptions extends Structure implements Structure.ByReference {
 
 	@Override
 	public String toString() {
-		return "DeviceOptions(Version=" + this.Version + ", ThreadCount=" + this.ThreadCount + ", Options=" + this.Options + ", mountOptions=" + this.getMountOptions() + ", GlobalContext=" + this.GlobalContext + ", MountPoint=" + this.MountPoint + ", UNCName=" + this.UNCName + ", Timeout=" + this.Timeout + ", AllocationUnitSize=" + this.AllocationUnitSize + ", SectorSize=" + this.SectorSize + ")";
+		return String.format("DeviceOptions(Version=%s, ThreadCount=%s, Options=%s, mountOptions=%s, GlobalContext=%s, MountPoint=%s, UNCName=%s, Timeout=%s, AllocationUnitSize=%s, SectorSize=%s)",
+				UnsignedNumbers.toUnsignedString(this.Version),
+				UnsignedNumbers.toUnsignedString(this.ThreadCount),
+				UnsignedNumbers.toUnsignedString(this.Options),
+				this.getMountOptions(),
+				UnsignedNumbers.toUnsignedString(this.GlobalContext),
+				this.MountPoint,
+				this.UNCName,
+				UnsignedNumbers.toUnsignedString(this.Timeout),
+				UnsignedNumbers.toUnsignedString(this.AllocationUnitSize),
+				UnsignedNumbers.toUnsignedString(this.SectorSize));
 	}
 }

--- a/src/main/java/dev/dokan/dokan_java/structure/DokanOptions.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/DokanOptions.java
@@ -22,21 +22,25 @@ public class DokanOptions extends Structure implements Structure.ByReference {
 	/**
 	 * Version of the Dokan features requested (version "123" is equal to Dokan version 1.2.3).
 	 */
+	@Unsigned
 	public short Version = DokanNativeMethods.getMinimumRequiredDokanVersion();
 
 	/**
 	 * Number of threads to be used internally by Dokan library. More thread will handle more events at the same time.
 	 */
+	@Unsigned
 	public short ThreadCount;
 
 	/**
 	 * Features enable for the mount. It is a combination of {@link MountOption} masks.
 	 */
+	@Unsigned
 	public int Options;
 
 	/**
 	 * FileSystem can store anything here
 	 */
+	@Unsigned
 	public long GlobalContext = 0L;
 
 	/**
@@ -54,16 +58,19 @@ public class DokanOptions extends Structure implements Structure.ByReference {
 	/**
 	 * Max timeout in milliseconds of each request before Dokan gives up to wait events to complete.
 	 */
+	@Unsigned
 	public int Timeout;
 
 	/**
 	 * Allocation Unit Size of the volume. This will affect the file size.
 	 */
+	@Unsigned
 	public int AllocationUnitSize;
 
 	/**
 	 * Sector Size of the volume. This will affect then file size.
 	 */
+	@Unsigned
 	public int SectorSize;
 
 	public DokanOptions() {

--- a/src/main/java/dev/dokan/dokan_java/structure/UnicodeString.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/UnicodeString.java
@@ -3,6 +3,7 @@ package dev.dokan.dokan_java.structure;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import dev.dokan.dokan_java.Unsigned;
 
 
 /**
@@ -17,11 +18,13 @@ public class UnicodeString extends Structure {
 	/**
 	 * The length, in bytes, of the string stored in {@link UnicodeString#Buffer}.
 	 */
+	@Unsigned
 	public short Length;
 
 	/**
 	 * The length, in bytes, of {@link UnicodeString#Buffer}.
 	 */
+	@Unsigned
 	public short MaximumLength;
 
 	/**

--- a/src/main/java/dev/dokan/dokan_java/structure/filesecurity/AccessControlList.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/filesecurity/AccessControlList.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Objectoriented implementation of the ACL-structure used in a {@link SelfRelativeSecurityDescriptor}.
+ * Object-oriented implementation of the ACL-structure used in a {@link SelfRelativeSecurityDescriptor}.
  * For more information, please read the <a href="https://msdn.microsoft.com/en-us/library/cc230297.aspx">official Microsoft documentation</a>.
  */
 public class AccessControlList implements Byteable {
@@ -55,7 +55,7 @@ public class AccessControlList implements Byteable {
 	private final short sbz2 = 0;
 
 	/**
-	 * List of AccessControlEntrys in this ACL
+	 * List of AccessControlEntries in this ACL
 	 */
 	private List<AccessControlEntry> aces;
 

--- a/src/main/java/dev/dokan/dokan_java/structure/filesecurity/SelfRelativeSecurityDescriptor.java
+++ b/src/main/java/dev/dokan/dokan_java/structure/filesecurity/SelfRelativeSecurityDescriptor.java
@@ -72,7 +72,7 @@ public class SelfRelativeSecurityDescriptor implements Byteable {
      * Sacl
      * The SACL of the object. The length of the SID MUST be a multiple of 4. This field MUST be present if the SP flag is set.
      * <p>
-     * This implementation guarantees the existence of a SACL if SP-flag is set by only writing the flag if this strucutre is present.
+     * This implementation guarantees the existence of a SACL if SP-flag is set by only writing the flag if this structure is present.
      */
     private Optional<AccessControlList> sacl;
 
@@ -80,12 +80,12 @@ public class SelfRelativeSecurityDescriptor implements Byteable {
      * Dacl
      * The DACL of the object. The length of the SID MUST be a multiple of 4. This field MUST be present if the DP flag is set.
      * <p>
-     * This implementation guarantees the existence of a DACL if DP-flag is set by only writing the flag if this strucutre is present.
+     * This implementation guarantees the existence of a DACL if DP-flag is set by only writing the flag if this structure is present.
      */
     private Optional<AccessControlList> dacl;
 
     /**
-     * Creates an empty SecurtiyDescriptor.
+     * Creates an empty SecurityDescriptor.
      *
      * @param control
      */
@@ -160,8 +160,8 @@ public class SelfRelativeSecurityDescriptor implements Byteable {
     @Override
     public int sizeOfByteArray() {
         return 2 // the first fixed bytes (revision and sbz1)
-                + 2 // the 16bit big  control mask
-                + 4 * 4 // the 4 32bit integer offset values indicating the offset to the following varaible length data fields
+                + 2 // the 16bit big control mask
+                + 4 * 4 // the 4 32bit integer offset values indicating the offset to the following variable length data fields
                 + ownerSid.map(SecurityIdentifier::sizeOfByteArray).orElse(0)
                 + groupSid.map(SecurityIdentifier::sizeOfByteArray).orElse(0)
                 + sacl.map(AccessControlList::sizeOfByteArray).orElse(0)


### PR DESCRIPTION
Added MAPPING.md as common guideline for type-conversions
Added new Annotation (Unsigned) used to indicate that an integer type or integer type pointer refers to an unsigned value.
Corrected types of fields in structures to match Dokany
Added Unsigned-Annotation to all accessors of unsigned values
Added UnsignedNumbers class with conversion methods between unsigned integer types and String

Merging this PR closes issue #46